### PR TITLE
with .bashrc in home dir checkout fails

### DIFF
--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -6,6 +6,7 @@ shopt -s expand_aliases
 alias config="/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME"
 echo ".cfg" >> .gitignore
 git clone --bare https://github.com/fastai/dotfiles.git .cfg/
+mv ~/.bashrc ~/.bashrc.local
 config checkout
 config config --local status.showUntrackedFiles no
 git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -6,7 +6,7 @@ shopt -s expand_aliases
 alias config="/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME"
 echo ".cfg" >> .gitignore
 git clone --bare https://github.com/fastai/dotfiles.git .cfg/
-mv ~/.bashrc ~/.bashrc.local
+rm ~/.bashrc
 config checkout
 config config --local status.showUntrackedFiles no
 git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2444926/93876805-b69afc00-fcd7-11ea-9090-f68f7f178246.png)

I am not sure if I am reading this right, assuming `.bashrc` is meant to become `.bashrc.local` for the time of the checkout and we append it to `.bashrc` afterwards