### PR TITLE
wrap $NAME in quotation marks

### DIFF
--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -20,7 +20,7 @@ if [[ $NAME ]]; then
 fi
 read -e -p "Enter your email (for git configuration): " EMAIL
 if [[ $EMAIL ]]; then
-  git config --global user.email "$EMAIL"
+  git config --global user.email $EMAIL
 fi
 
 cd -


### PR DESCRIPTION
Fixes an issue where `.gitconfig` is not properly updated when name consists of more than a single word (FIRST_NAME LAST_NAME for example)