### PR TITLE
add cron installation to ubuntu-initial.sh

### DIFF
--- a/ubuntu-initial.sh
+++ b/ubuntu-initial.sh
@@ -63,7 +63,7 @@ apt-fast -qy install python
 apt-fast -qy install vim-nox python3-powerline rsync ubuntu-drivers-common python3-pip ack lsyncd wget bzip2 ca-certificates git build-essential \
   software-properties-common curl grep sed dpkg libglib2.0-dev zlib1g-dev lsb-release tmux less htop exuberant-ctags openssh-client python-is-python3 \
   python3-pip python3-dev dos2unix gh pigz ufw bash-completion ubuntu-release-upgrader-core unattended-upgrades cpanminus libmime-lite-perl \
-  opensmtpd mailutils
+  opensmtpd mailutils cron
 env DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=mail apt-fast full-upgrade -qy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'
 sudo apt -qy autoremove
 


### PR DESCRIPTION
Turns out, ubuntu minimal images do not come with cron installed. Assuming this is something that might be needed in a lot of situations hence the PR. 

(since cron is available out of the box generally googling for how to install it, or googling the error message one receives when it is not installed, does not give really good answers, which can be particularly problematic for less experienced users)