### PR TITLE
Aarch64 install added

### DIFF
--- a/setup-conda.sh
+++ b/setup-conda.sh
@@ -7,7 +7,11 @@ case "$OSTYPE" in
       arm64)  DOWNLOAD=https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh; ;;
       *)      DOWNLOAD=https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-x86_64.sh; ;;
     esac ;;
-  linux*)     DOWNLOAD=https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh; ;;
+  linux*)
+    case $(uname -m) in
+      aarch64) DOWNLOAD=https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-aarch64.sh; ;;
+      *)       DOWNLOAD=https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh; ;;
+      esac ;;
   *)          echo "unknown: $OSTYPE" ;;
 esac
 


### PR DESCRIPTION
This PR will add Aarch64 to the setup conda script. Helpful when trying to install fastsetup on a Raspberry Pi.  