### PR TITLE
Fixed github repo key and ssh restart in ubuntu-wsl.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,25 @@
 
 First, do basic ubuntu configuration, such as updating packages, and turning on auto-updates:
 
+## If you are running in WSL, run the correct sections below.
+
+### non-WSL-only
+
 ```
 sudo apt update && sudo apt -y install git
 git clone https://github.com/fastai/fastsetup.git
 cd fastsetup
 sudo ./ubuntu-initial.sh
 # wait a couple of minutes for reboot, then ssh back in
+```
+
+### WSL-only
+
+```
+sudo apt update && sudo apt -y install git
+git clone https://github.com/fastai/fastsetup.git
+cd fastsetup
+sudo ./ubuntu-wsl.sh
 ```
 
 Then, optionally, set up [dotfiles](https://github.com/fastai/dotfiles):
@@ -35,9 +48,35 @@ Replace `EMAIL_ADDR` with an address to send to. You can get a useful testing ad
 
 To install NVIDIA drivers, if required:
 
+### non-WSL-only:
+
 ```
 ubuntu-drivers devices
 sudo apt-fast install -y nvidia-XXX
 sudo modprobe nvidia
 nvidia-smi
 ```
+
+### WSL-only:
+
+Install the latest NVIDIA driver on your Windows PC running WSL
+Then do a special install of cuda
+
+```
+sudo apt-key del 7fa2af80
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
+wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-wsl-ubuntu.pin
+sudo mv cuda-wsl-ubuntu.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda-repo-wsl-ubuntu-11-7-local_11.7.0-1_amd64.deb
+sudo dpkg -i cuda-repo-wsl-ubuntu-11-7-local_11.7.0-1_amd64.deb
+sudo apt-get update
+sudo apt-fast install -y cuda
+nvidia-smi
+```
+
+(WSL-only): Don't worry if nvidia-smi reports
+ "Internal Error" under the "Processes" heading.
+
+If it's working, you should still see part of your GPU name,
+and how much memory is available in the first heading.

--- a/ubuntu-wsl.sh
+++ b/ubuntu-wsl.sh
@@ -7,10 +7,12 @@ echo 'Defaults        timestamp_timeout=3600' >> /etc/sudoers
 
 CODENAME=$(lsb_release -cs)
 cat >> /etc/apt/sources.list << EOF
-deb https://cli.github.com/packages $CODENAME main
 deb http://ppa.launchpad.net/apt-fast/stable/ubuntu $CODENAME main
 EOF
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C99B11DEB97541F0 1EE2FF37CA8DA16B
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1EE2FF37CA8DA16B
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list
 apt-get update
 
 export DEBIAN_FRONTEND=noninteractive
@@ -33,6 +35,12 @@ ChallengeResponseAuthentication no
 PermitEmptyPasswords no
 PermitRootLogin no
 EOF
-systemctl reload ssh
+# broken because WSL doesn't yet support systemd
+# Support was just added, but not yet out of preview
+# see here for details:
+# https://ubuntu.com/blog/ubuntu-wsl-enable-systemd
+#
+#systemctl reload ssh
+service ssh restart
 
 python -m pip install pip -Uq


### PR DESCRIPTION
Copied the fix for the expired github repo signing key from ubuntu-initial.sh

Replaced the systemd method of restarting ssh with service command version.
(systemd support is coming to WSL, but not yet, so I left a link to the info about that)
    - Allows script to finish, and do final pip update