### PR TITLE
replace python with python3

### DIFF
--- a/ubuntu-initial.sh
+++ b/ubuntu-initial.sh
@@ -61,7 +61,7 @@ EOF
 
 chown root:root /etc/{logrotate,apt-fast}.conf /etc/systemd/journald.conf /etc/apt/apt.conf.d/{50unattended-upgrades,10periodic}
 
-apt-fast -qy install python
+apt-fast -qy install python3
 apt-fast -qy install vim-nox python3-powerline rsync ubuntu-drivers-common python3-pip ack lsyncd wget bzip2 ca-certificates git build-essential \
   software-properties-common curl grep sed dpkg libglib2.0-dev zlib1g-dev lsb-release tmux less htop exuberant-ctags openssh-client python-is-python3 \
   python3-pip python3-dev dos2unix gh pigz ufw bash-completion ubuntu-release-upgrader-core unattended-upgrades cpanminus libmime-lite-perl \


### PR DESCRIPTION
Ubuntu stopped shipping python (2.7) packages.