### PR TITLE
replace python with python3

### DIFF
--- a/ubuntu-wsl.sh
+++ b/ubuntu-wsl.sh
@@ -20,7 +20,7 @@ apt-get -qy install apt-fast
 cp apt-fast.conf /etc/
 chown root:root /etc/apt-fast.conf
 
-apt-fast -qy install python
+apt-fast -qy install python3
 apt-fast -qy install vim-nox python3-powerline rsync ubuntu-drivers-common python3-pip ack lsyncd wget bzip2 ca-certificates git build-essential \
   software-properties-common curl grep sed dpkg libglib2.0-dev zlib1g-dev lsb-release tmux less htop exuberant-ctags openssh-client python-is-python3 \
   python3-pip python3-dev dos2unix gh pigz ufw bash-completion ubuntu-release-upgrader-core unattended-upgrades cpanminus libmime-lite-perl \


### PR DESCRIPTION
fixes "e: package 'python' has no installation candidate package manager quit with exit code." error